### PR TITLE
Optional search features and filtering

### DIFF
--- a/lib/provider.py
+++ b/lib/provider.py
@@ -114,6 +114,9 @@ def perform_search(search_type, data):
         for scraper, scraper_results in runner_data:
             logging.debug("Processing %s scraper results", scraper.name)
             for scraper_result in scraper_results:
+                if not scraper_result["title"]:
+                  continue
+
                 magnet = Magnet(scraper_result["magnet"])
                 try:
                     info_hash = magnet.parse_info_hash()

--- a/lib/provider.py
+++ b/lib/provider.py
@@ -98,6 +98,25 @@ class Result(object):
         return max(seeds * seeds_factor + leeches * leeches_factor, 1) * resolution
 
 
+def include_result(result):
+    if get_boolean_setting("require_size") and not bool(result._size):
+        return False
+
+    if get_boolean_setting("require_seeds") and not bool(result.seeds):
+        return False
+
+    if get_boolean_setting("require_resolution"):
+        resolution = result._resolution.name.lower()
+        if not get_boolean_setting("include_{}".format(resolution)):
+            return False
+
+    if get_boolean_setting("require_release_type"):
+        release = result._release.name.lower()
+        if not get_boolean_setting("include_{}".format(release)):
+            return False
+    return True
+
+
 def perform_search(search_types, data):
     results = {}
     scrapers = [s for s in Scraper.get_scrapers(os.path.join(ADDON_PATH, "resources", "providers.json"),
@@ -138,7 +157,9 @@ def perform_search(search_types, data):
 
                     magnet_result = results.get(info_hash)  # type: Result
                     if magnet_result is None:
-                        results[info_hash] = Result(scraper, scraper_result)
+                        result = Result(scraper, scraper_result)
+                        if include_result(result):
+                            results[info_hash] = result
                     else:
                         magnet_result.add_result(scraper, scraper_result)
 

--- a/lib/provider.py
+++ b/lib/provider.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 try:
     from urllib import quote_plus
@@ -122,6 +123,11 @@ def perform_search(search_types, data):
                     if not title:
                         continue
 
+                    if "episode" in search_types and search_type == "season":
+                        if re.search(r"E\d{2,}\s?-\s?\d{2,}", title, re.I) is None:
+                            if len(re.findall(r"E\d{2,}", title, re.I)) == 1:
+                                continue
+
                     magnet = Magnet(scraper_result["magnet"])
                     try:
                         info_hash = magnet.parse_info_hash()
@@ -174,7 +180,11 @@ class MagnetoProvider(Provider):
         return perform_search("season", dict(tmdb_id=tmdb_id, title=Title(show_title, titles), season=season_number))
 
     def search_episode(self, tmdb_id, show_title, season_number, episode_number, titles):
-        return perform_search("episode", dict(
+        search_types = ["episode"]
+        if get_boolean_setting("include_season_results"):
+          search_types.append("season")
+
+        return perform_search(search_types, dict(
             tmdb_id=tmdb_id, title=Title(show_title, titles), season=season_number, episode=episode_number))
 
     def resolve(self, provider_data):

--- a/lib/provider.py
+++ b/lib/provider.py
@@ -128,7 +128,7 @@ def perform_search(search_types, data):
         return None
 
     if not isinstance(search_types, list):
-      search_types = [search_types]
+        search_types = [search_types]
 
     runner_class = ProgressScraperRunner if get_boolean_setting("enable_bg_dialog") else ScraperRunner
     with runner_class(scrapers, num_threads=get_int_setting("thread_number")) as runner:
@@ -203,7 +203,7 @@ class MagnetoProvider(Provider):
     def search_episode(self, tmdb_id, show_title, season_number, episode_number, titles):
         search_types = ["episode"]
         if get_boolean_setting("include_season_results"):
-          search_types.append("season")
+            search_types.append("season")
 
         return perform_search(search_types, dict(
             tmdb_id=tmdb_id, title=Title(show_title, titles), season=season_number, episode=episode_number))

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -8,6 +8,7 @@ from string import Formatter
 import requests
 
 from lib.parsers import HTMLParser, JSONParser, XMLParser
+from lib.filters import Resolution, ReleaseType
 
 try:
     # noinspection PyUnresolvedReferences
@@ -240,7 +241,26 @@ def generate_settings(path, enabled_count=-1):
     <!-- Providers -->
     <category label="30001">{}
     </category>
+    <!-- Filters -->
+    <category label="30020">
+        <setting id="require_resolution" type="bool" label="30021" default="false" />
+        <setting id="require_release_type" type="bool" label="30022" default="false" />
+        <setting id="require_size" type="bool" label="30023" default="false" />
+        <setting id="require_seeds" type="bool" label="30024" default="false" />
+    </category>
+    <!-- Resolutions -->
+    <category label="30030">{}
+    </category>
+    <!-- Release Types -->
+    <category label="30040">{}
+    </category>
 </settings>""".format(
         "".join('\n{}<setting id="{}" type="bool" label="{}" default="{}"/>'.format(
             " " * 4 * 2, scraper.id, scraper.name, "false" if 0 <= enabled_count <= i else "true")
-                for i, scraper in enumerate(Scraper.get_scrapers(path))))
+                for i, scraper in enumerate(Scraper.get_scrapers(path))),
+        "".join('\n{}<setting id="include_{}" type="bool" label="{}" default="true"/>'.format(
+            " " * 4 * 2, resolution.name.lower(), resolution.name)
+                for resolution in reversed(Resolution.values)),
+        "".join('\n{}<setting id="include_{}" type="bool" label="{}" default="true"/>'.format(
+            " " * 4 * 2, release.name.lower(), release.name)
+                for release in ReleaseType.values))

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -181,10 +181,14 @@ class Scraper(object):
         return self.parse_query(self._format_query(keyword, formats), pool=pool)
 
     def parse_query(self, query, pool=None):
-        results = self._parse_results(query)
-        for parser in self._additional_parsers:
-            _run(pool, self._parse_additional, [(parser, result) for result in results])
-        return results
+        try:
+            results = self._parse_results(query)
+            for parser in self._additional_parsers:
+                _run(pool, self._parse_additional, [(parser, result) for result in results])
+            return results
+        except Exception as e:
+            logging.error("Failed parsing results for scraper %s: %s", self.name, e)
+            return list()
 
 
 class ScraperRunner(object):

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -235,6 +235,7 @@ def generate_settings(path, enabled_count=-1):
         <setting id="scraper_timeout" type="slider" label="30002" option="int" range="10,1,60" default="30"/>
         <setting id="thread_number" type="slider" label="30004" option="int" range="1,1,50" default="10"/>
         <setting id="enable_bg_dialog" type="bool" label="30003" default="true"/>
+        <setting id="include_season_results" type="bool" label="30005" default="false"/>
     </category>
     <!-- Providers -->
     <category label="30001">{}

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -42,6 +42,34 @@ msgctxt "#30005"
 msgid "Include season results in episode search"
 msgstr ""
 
+msgctxt "#30020"
+msgid "Filters"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Require resolution"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Require release type"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Require file size"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Require seeds"
+msgstr ""
+
+msgctxt "#30030"
+msgid "Resolutions"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Releases"
+msgstr ""
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -38,6 +38,10 @@ msgctxt "#30004"
 msgid "Threads number"
 msgstr ""
 
+msgctxt "#30005"
+msgid "Include season results in episode search"
+msgstr ""
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -38,6 +38,10 @@ msgctxt "#30004"
 msgid "Threads number"
 msgstr "Número de threads"
 
+msgctxt "#30005"
+msgid "Include season results in episode search"
+msgstr "Incluir os resultados da temporada na busca de episódios"
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -52,7 +52,7 @@ msgstr "Exigir resolução"
 
 msgctxt "#30022"
 msgid "Require release type"
-msgstr "Exigir tipo de liberação"
+msgstr "Exigir tipo de lançamento"
 
 msgctxt "#30023"
 msgid "Require file size"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -42,6 +42,34 @@ msgctxt "#30005"
 msgid "Include season results in episode search"
 msgstr "Incluir os resultados da temporada na busca de episódios"
 
+msgctxt "#30020"
+msgid "Filters"
+msgstr "Filtros"
+
+msgctxt "#30021"
+msgid "Require resolution"
+msgstr "Exigir resolução"
+
+msgctxt "#30022"
+msgid "Require release type"
+msgstr "Exigir tipo de liberação"
+
+msgctxt "#30023"
+msgid "Require file size"
+msgstr "Exigir tamanho do arquivo"
+
+msgctxt "#30024"
+msgid "Require seeds"
+msgstr "Exigir seeds"
+
+msgctxt "#30030"
+msgid "Resolutions"
+msgstr "Resoluções"
+
+msgctxt "#30040"
+msgid "Releases"
+msgstr "Lançamentos"
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -38,6 +38,10 @@ msgctxt "#30004"
 msgid "Threads number"
 msgstr "Número de threads"
 
+msgctxt "#30005"
+msgid "Include season results in episode search"
+msgstr "Incluir os resultados da época na pesquisa de episódios"
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -40,7 +40,7 @@ msgstr "Número de threads"
 
 msgctxt "#30005"
 msgid "Include season results in episode search"
-msgstr "Incluir os resultados da época na pesquisa de episódios"
+msgstr "Incluir os resultados da temporada na pesquisa de episódios"
 
 msgctxt "#30020"
 msgid "Filters"
@@ -52,7 +52,7 @@ msgstr "Exigir resolução"
 
 msgctxt "#30022"
 msgid "Require release type"
-msgstr "Exigir tipo de liberação"
+msgstr "Exigir tipo de lançamento"
 
 msgctxt "#30023"
 msgid "Require file size"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -42,6 +42,34 @@ msgctxt "#30005"
 msgid "Include season results in episode search"
 msgstr "Incluir os resultados da época na pesquisa de episódios"
 
+msgctxt "#30020"
+msgid "Filters"
+msgstr "Filtros"
+
+msgctxt "#30021"
+msgid "Require resolution"
+msgstr "Exigir resolução"
+
+msgctxt "#30022"
+msgid "Require release type"
+msgstr "Exigir tipo de liberação"
+
+msgctxt "#30023"
+msgid "Require file size"
+msgstr "Exigir tamanho do arquivo"
+
+msgctxt "#30024"
+msgid "Require seeds"
+msgstr "Exigir seeds"
+
+msgctxt "#30030"
+msgid "Resolutions"
+msgstr "Resoluções"
+
+msgctxt "#30040"
+msgid "Releases"
+msgstr "Lançamentos"
+
 # Script
 msgctxt "#30100"
 msgid "Processing"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,4 +10,38 @@
     <!-- Providers -->
     <category label="30001">
     </category>
+    <!-- Filters -->
+    <category label="30020">
+        <setting id="require_resolution" type="bool" label="30021" default="false" />
+        <setting id="require_release_type" type="bool" label="30022" default="false" />
+        <setting id="require_size" type="bool" label="30023" default="false" />
+        <setting id="require_seeds" type="bool" label="30024" default="false" />
+    </category>
+    <!-- Resolutions -->
+    <category label="30030">
+        <setting id="include_4k" type="bool" label="4K" default="true"/>
+        <setting id="include_2k" type="bool" label="2K" default="true"/>
+        <setting id="include_1080p" type="bool" label="1080p" default="true"/>
+        <setting id="include_720p" type="bool" label="720p" default="true"/>
+        <setting id="include_480p" type="bool" label="480p" default="true"/>
+        <setting id="include_240p" type="bool" label="240p" default="true"/>
+    </category>
+    <!-- Release Types -->
+    <category label="30040">
+        <setting id="include_trailer" type="bool" label="Trailer" default="true"/>
+        <setting id="include_workprint" type="bool" label="Workprint" default="true"/>
+        <setting id="include_vhsrip" type="bool" label="VHSrip" default="true"/>
+        <setting id="include_tvrip" type="bool" label="TVRip" default="true"/>
+        <setting id="include_cam" type="bool" label="CAM" default="true"/>
+        <setting id="include_telesync" type="bool" label="TeleSync" default="true"/>
+        <setting id="include_telecine" type="bool" label="TeleCine" default="true"/>
+        <setting id="include_screener" type="bool" label="Screener" default="true"/>
+        <setting id="include_dvdscreener" type="bool" label="DVDScreener" default="true"/>
+        <setting id="include_r5" type="bool" label="R5" default="true"/>
+        <setting id="include_dvdrip" type="bool" label="DVDRip" default="true"/>
+        <setting id="include_hdtv" type="bool" label="HDTV" default="true"/>
+        <setting id="include_hdrip" type="bool" label="HDRip" default="true"/>
+        <setting id="include_webdl" type="bool" label="WebDL" default="true"/>
+        <setting id="include_brrip" type="bool" label="BRRip" default="true"/>
+    </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
         <setting id="scraper_timeout" type="slider" label="30002" option="int" range="10,1,60" default="30"/>
         <setting id="thread_number" type="slider" label="30004" option="int" range="1,1,50" default="10"/>
         <setting id="enable_bg_dialog" type="bool" label="30003" default="true"/>
+        <setting id="include_season_results" type="bool" label="30005" default="false"/>
     </category>
     <!-- Providers -->
     <category label="30001">


### PR DESCRIPTION
Hey @i96751414, this adds some optional features that can be enabled in settings.

- Include complete season results when searching for episodes
- Filters search results by seeds, file size, resolution and release type

Also it skips results that don't have a title (was causing errors) and prevents search failure if one/some providers fail.
The PT translations are from google and they may be inaccurate.